### PR TITLE
Drop fixes

### DIFF
--- a/DoubleOreDropConfig.cs
+++ b/DoubleOreDropConfig.cs
@@ -9,6 +9,8 @@ namespace DoubleOreDrop
 	public class DoubleOreDropConfig : ModConfig
 	{
 		public override ConfigScope Mode => ConfigScope.ServerSide; //Change to client to make it only applicable to the client side
+		//DropChance won't work if clientside, because Drop() is called serverside.
+		//if MiningSpeed is clientside, it will desync in multiplayer for different values
 
 		[Header("Reduced Mining Ore Drop Chance")]
 		[Label("Set Ore Drop Chance; Current Chance")]
@@ -33,5 +35,7 @@ namespace DoubleOreDrop
 			DoubleOreDrop.DropChance = DropChance;
 			DoubleOreDrop.MiningSpeed = -MiningSpeed;
 		}
+
+		
 	}
 }

--- a/DoubleOreDropConfig.cs
+++ b/DoubleOreDropConfig.cs
@@ -1,6 +1,6 @@
-
 using System.ComponentModel;
-using Microsoft.Xna.Framework;
+using System.Runtime.Serialization;
+using Terraria;
 using Terraria.ModLoader.Config;
 
 namespace DoubleOreDrop
@@ -21,8 +21,8 @@ namespace DoubleOreDrop
 		[Slider]
 		public float DropChance;
 
-		[Header("Increase or Reduce Mining Speed")]
-		[Label("Increase/Decreas; Current Increase/Decrease %")]
+		[Header("Increase or Decrease Mining Speed")]
+		[Label("Increase/Decrease; Current Increase/Decrease %")]
 		[Tooltip("-3 = '-300% Decrease', 3 = '300% Increase'")]
 		[Increment(0.1f)]
 		[Range(-3f, 3f)]
@@ -36,6 +36,12 @@ namespace DoubleOreDrop
 			DoubleOreDrop.MiningSpeed = -MiningSpeed;
 		}
 
-		
+		//For when someone edits the config file directly
+		[OnDeserialized]
+		internal void OnDeserializedMethod(StreamingContext context)
+        {
+			DropChance = Utils.Clamp(DropChance, 0f, 1f);
+			MiningSpeed = Utils.Clamp(MiningSpeed, -3f, 3f);
+		}
 	}
 }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -5,6 +5,12 @@
       "executablePath": "$(tMLPath)",
       "workingDirectory": "$(TerrariaSteamPath)"
     },
+    "TerrariaFast": {
+      "commandName": "Executable",
+      "executablePath": "$(tMLPath)",
+      "commandLineArgs": "-skipselect",
+      "workingDirectory": "$(TerrariaSteamPath)"
+    },
     "TerrariaServer": {
       "commandName": "Executable",
       "executablePath": "$(tMLServerPath)",

--- a/Tiles/DoubleOreDropGlobalTile.cs
+++ b/Tiles/DoubleOreDropGlobalTile.cs
@@ -1,6 +1,4 @@
-﻿
-using Microsoft.Xna.Framework;
-using Terraria.ID;
+﻿using Terraria.ID;
 using Terraria;
 using Terraria.ModLoader;
 using System.Collections.Generic;
@@ -9,7 +7,7 @@ namespace DoubleOreDrop.Tiles
 {
     public class DoubleOreDropGlobalTile : GlobalTile
     {
-        Dictionary<int, int> OreDrops = new Dictionary<int, int>()
+        public static readonly Dictionary<int, int> OreDrops = new Dictionary<int, int>()
         {
             {TileID.Copper, ItemID.CopperOre},
             {TileID.Tin, ItemID.TinOre},
@@ -33,26 +31,34 @@ namespace DoubleOreDrop.Tiles
             {TileID.LunarOre, ItemID.LunarOre},
             {TileID.Lead, ItemID.LeadOre},
         };
+
         public override bool Drop(int i, int j, int type)
         {
-            if (Main.rand.NextFloat() <= DoubleOreDrop.DropChance)
+            //Easy exploit, break ore, place ore, break ore, etc
+            if (WorldGen.genRand.NextFloat() <= DoubleOreDrop.DropChance)
             {
-                if (Terraria.ID.TileID.Sets.Ore[type] && !(TileLoader.GetTile(type) is ModTile)) //Vanilla
-                {
-                    Item.NewItem(i * 16, j * 16, 16, 16, OreDrops[type], 1, false, -1, false, false);
-                }
+                ModTile modTile = TileLoader.GetTile(type);
 
-                if (TileLoader.GetTile(type) is ModTile && TileLoader.GetTile(type).Name.Contains("Ore")) //Modded
+                if (modTile == null)
                 {
-                    ModTile tile = TileLoader.GetTile(type);
-
-                    if (tile != null)
+                    //Vanilla
+                    if (TileID.Sets.Ore[type] && OreDrops.TryGetValue(type, out int item))
                     {
-                        if (tile.drop > 0)
+                        Item.NewItem(i * 16, j * 16, 16, 16, item, 1, false, -1, false, false);
+                    }
+                }
+                else
+                {
+                    //Modded
+                    //modTile.Name.Contains("Ore") is a bad way to detect if it's a modded ore. If the modder is smart he should have added his tile to TileID.Sets.Ore properly
+                    //If not, let the modder know of the ore that doesn't work
+                    if (TileID.Sets.Ore[type])
+                    {
+                        int drop = modTile.drop;
+                        if (drop > 0)
                         {
-                            Item.NewItem(i * 16, j * 16, 16, 16, tile.drop, 1, false, -1, false, false);
+                            Item.NewItem(i * 16, j * 16, 16, 16, drop, 1, false, -1, false, false);
                         }
-                        return true;
                     }
                 }
             }


### PR DESCRIPTION
This PR adds a few comments regarding the config, config edit protection, and revamped `Drop` code that is safe. It will not catch all modded ores (only those that are correctly registered as ores to vanilla) but it will also not catch things that aren't ores and just have "Ore" in their name (for example an Ore Excavator tile). It adds comments about this aswell.

What still needs work is a way to only duplicate initially spawned ores, as currently you can just duplicates ores by placing and breaking them repeatedly. But I have an idea as to how to do this

Your published mod browser version is also ahead of the github source code, always make sure to push the code before publishing (1.0.0.1 on github, 1.0.0.2 on the browser). This could lead to troubles merging this PR, and if so, reject your build.txt change, merge, and then increment it later when you publish.